### PR TITLE
Introduce tests and copy file from script #16

### DIFF
--- a/harvestHoldings_prod.sh
+++ b/harvestHoldings_prod.sh
@@ -2,15 +2,30 @@
 
 Metafacture_Runner=$1
 
+# Test function for Testing if harvesting or transformation failed
+die() {
+    local message=$1
+
+    echo "$message" >&2
+    exit 1
+}
+
 # Create Holdings from old ALEPH Seq Dump
 echo "Start transformation for ALEPH Seq Data" && date
-$Metafacture_Runner flux/mab2De-Sol1Holdings_seq_prod.flux outfile2="prod/output/sol1Holding_seq.tsv.gz"
+$Metafacture_Runner flux/mab2De-Sol1Holdings_seq_prod.flux outfile2="prod/output/sol1Holding_seq.tsv.gz" || die 'Harvesting or Transformation of Seq Data failed'
 
-# Create Holdings from SRU Request
+# Create Holdings from ZDB SRU Request
 echo "Start transformation for SRU Data" && date
-$Metafacture_Runner flux/zdbSru2De-Sol1Holdings_marc_prod.flux outfile2="prod/output/sol1Holding_sru.tsv.gz"
+$Metafacture_Runner flux/zdbSru2De-Sol1Holdings_marc_prod.flux outfile2="prod/output/sol1Holding_sru.tsv.gz" || die 'Harvesting or Transformation of ZDB SRU Data failed'
 
 # Concatinate results
 echo "Combine output in single file combinedDe-Sol1Holdings.tsv.gz" && date
 $Metafacture_Runner flux/combineFiles_prod.flux
 echo "Done" && date
+
+numberOfLines=(wc -l ./prod/output/combinedDe-Sol1Holdings.tsv.gz)
+if (numberOfLines > 80000)
+	cp ./prod/output/combinedDe-Sol1Holdings.tsv.gz ..lobid-resources/src/main/resources/alma/maps/combinedDe-Sol1Holdings.tsv.gz
+else
+	echo "Number of lines too small"
+end

--- a/harvestHoldings_test.sh
+++ b/harvestHoldings_test.sh
@@ -2,13 +2,22 @@
 
 Metafacture_Runner=$1
 
+# Test function for Testing if harvesting or transformation failed
+die() {
+    local message=$1
+
+    echo "$message" >&2
+    exit 1
+}
+
 # Create Holdings from old ALEPH Seq Dump
 echo "Start transformation for ALEPH Seq Data" && date
-$Metafacture_Runner flux/mab2De-Sol1Holdings_seq_test.flux outfile2="test/output/sol1Holding_seq.tsv"
+$Metafacture_Runner flux/mab2De-Sol1Holdings_seq_test.flux outfile2="test/output/sol1Holding_seq.tsv" || die 'Harvesting or Transformation of Seq Data failed'
 
-# Create Holdings from SRU Request
+
+# Create Holdings from  ZDB SRU Request
 echo "Start transformation for SRU Data" && date
-$Metafacture_Runner flux/zdbSru2De-Sol1Holdings_marc_test.flux outfile2="test/output/sol1Holding_sru.tsv"
+$Metafacture_Runner flux/zdbSru2De-Sol1Holdings_marc_test.flux outfile2="test/output/sol1Holding_sru.tsv" || die 'Harvesting or Transformation of ZDB SRU Data failed'
 
 # Concatinate results
 echo "Combine output in single file combinedDe-Sol1Holdings.tsv" && date


### PR DESCRIPTION
I introduced tests for the script as discussed.

The metafacture runner is now part of the repo and can be used with the following path:  `./metafacture-core/flux.sh`