### PR TITLE
Reuse the fallback mapping lookup for the strapi preprocessing #29

### DIFF
--- a/fix/mab2De-Sol1Holdings_seq2strapi.fix
+++ b/fix/mab2De-Sol1Holdings_seq2strapi.fix
@@ -2,6 +2,9 @@ do once("maps_macros")
   put_filemap("../prod/map/identifier.tsv", "hbzId2AlmaMmsId", sep_char:"\t", key_column:"1", value_column:"0", expected_columns:"-1")
   put_filemap("../prod/map/identifier.tsv", "zdbId2AlmaMmsId", sep_char:"\t", key_column:"2", value_column:"0", expected_columns:"-1")
   put_filemap("../prod/map/identifier.tsv", "hbzId2zdbId", sep_char:"\t", key_column:"1", value_column:"2", expected_columns:"-1")
+  put_filemap("../prod/map/htMap.tsv", "htMap2AlmaMmsId", sep_char:"\t", key_column:"2", value_column:"1", expected_columns:"-1")
+  put_filemap("../prod/map/htMap.tsv", "htMap2ZdbId", sep_char:"\t", key_column:"2", value_column:"3", expected_columns:"-1")
+
 
   do put_macro("normalize_date")
     replace_all("$[field]", "^(\\d{4})(\\d{2})(\\d{2}).*$", "$1-$2-$3")
@@ -97,10 +100,16 @@ else # Transformation for the ME records
 
 end
 
+copy_field("zdbId", "zdbId_fallback")
 lookup("zdbId", "hbzId2zdbId", delete:"true")
+lookup("zdbId_fallback", "htMap2ZdbId", delete:"true")
+unless exists("zdbId")
+  copy_field("zdbId_fallback", "zdbId")
+end
 
 if any_match("almaMmsId", "^[A-Z]{2}.*")
   lookup("almaMmsId", "hbzId2AlmaMmsId")
+  lookup("almaMmsId", "htMap2AlmaMmsId")  # Uses a fallback map for HT Numbers that were not present in last ALEPH Bridge.
 else
   lookup("almaMmsId", "zdbId2AlmaMmsId")
 end

--- a/test/output/sol1Holding_strapi.json
+++ b/test/output/sol1Holding_strapi.json
@@ -8745,11 +8745,11 @@
 },{
   "holdingId" : "HL022022994",
   "dateCreated" : "2022-10-13",
-  "id" : "http://lobid.org/resources/HT021432025#!",
-  "lobidUri" : "http://lobid.org/resources/HT021432025#!",
+  "id" : "http://lobid.org/resources/99371454179906441#!",
+  "lobidUri" : "http://lobid.org/resources/99371454179906441#!",
   "hbzId" : "HT021432025",
   "doNotIndex" : "false",
-  "almaMmsId" : "HT021432025",
+  "almaMmsId" : "99371454179906441",
   "hasItem" : [ {
     "itemId" : "HBZ60072791546-000010",
     "dateCreated" : "2022-10-13",


### PR DESCRIPTION
When writing the transformation for the strapi import I did not include the fallback mapping for missing mappings for hbzId -> almaMmsId I [implemented for the aleph data.](https://github.com/hbz/lobid-extra-holdings/pull/23)

I implemented this now for the strapi import too.

Resolves #29